### PR TITLE
[change] Ensure compatibility with Security-Patch SUPEE-11314

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release Notes - heidelpay extension for Magento 1
 
 ## vXX.X.XX
+### Added
+- Ensure compatibility with Security-Patch SUPEE-11314
+
 ## Fixed
 - Custom status for processing was not set as expected.
 

--- a/app/code/community/HeidelpayCD/Edition/Model/Resource/Encryption.php
+++ b/app/code/community/HeidelpayCD/Edition/Model/Resource/Encryption.php
@@ -18,18 +18,13 @@
 // @codingStandardsIgnoreLine magento marketplace namespace warning
 class HeidelpayCD_Edition_Model_Resource_Encryption extends Mage_Core_Model_Encryption
 {
-    public function hash($data)
-    {
-        return hash('sha256', $data);
-    }
-    
     public function getHash($string, $salt = false)
     {
         if ($salt === false) {
             $salt = (string)Mage::getConfig()->getNode('global/crypt/key');
         }
 
-        return $this->hash($salt.(string)$string);
+        return hash('sha256', $salt . $string);
     }
     
     public function validateHash($string, $hash)


### PR DESCRIPTION
- Avoid overwriting Mage_Core_Model_Encryption::hash since function
definition varies.